### PR TITLE
adding the base files to create static docs site for webpack-dashboard

### DIFF
--- a/.builderrc
+++ b/.builderrc
@@ -1,0 +1,3 @@
+---
+archetypes:
+  - builder-docs-archetype

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,2 @@
+---
+extends: ./node_modules/builder-docs-archetype/config/eslint/.eslintrc-config

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+\.git
+\.hg
+
+\.DS_Store
+\.project
+bower_components
+node_modules
+npm-debug\.log*
+phantomjsdriver\.log
+
+# Build
+coverage
+Procfile
+build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# webpack-dashboard-docs
-Documentation for webpack-dashboard
+# Webpack-Dashboard Documentation
+Documentation for webpack-dashboard, a CLI dashboard for webpack dev server.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>Component Playground</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link rel="icon" href="./static/favicon.ico" type="image/x-icon">
+  <base href="/" />
+  <!-- Code Mirror -->
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.css"/>
+</head>
+<body>
+  <div id="content">
+    <p style="text-align: center;">Oops! Something is broken or JavaScript is not enabled.</p>
+  </div>
+  <script async defer type="text/javascript" src="main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "webpack-dashboard-docs",
+  "version": "0.0.1",
+  "description": "Documentation site for Webpack Dashboard",
+  "main": "webpack.config.dev.js",
+  "scripts": {
+    "start": "builder run dev",
+    "test": "builder run lint",
+    "update-project": "npm update webpack-dashboard"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FormidableLabs/webpack-dashboard-docs.git"
+  },
+  "author": "emma.brillhart@formidable.com",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/FormidableLabs/webpack-dashboard-docs/issues"
+  },
+  "homepage": "https://github.com/FormidableLabs/webpack-dashboard-docs#readme",
+  "devDependencies": {
+    "builder-docs-archetype-dev": "^3.0.2",
+    "react-docgen": "2.7.0"
+  },
+  "dependencies": {
+    "babel-preset-stage-1": "^6.5.0",
+    "builder": "^2.9.1",
+    "builder-docs-archetype": "^3.0.2",
+    "chai": "^3.2.0",
+    "webpack-dashboard": "FormidableLabs/webpack-dashboard",
+    "ecology": "^1.6.0",
+    "formidable-landers": "^3.3.3",
+    "history": "~1.17.0",
+    "lodash": "^4.6.1",
+    "marked": "^0.3.5",
+    "mocha": "^2.3.3",
+    "radium": "0.17.2",
+    "react": "^15.1.0",
+    "react-addons-test-utils": "^15.1.0",
+    "react-document-meta": "^2.0.3",
+    "react-dom": "^15.1.0",
+    "react-ga": "^2.1.1",
+    "react-router": "^2.0.1",
+    "react-router-scroll": "^0.2.0",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0"
+  }
+}

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,2 @@
+---
+extends: ../node_modules/builder-docs-archetype/config/eslint/.eslintrc-react

--- a/src/basename.js
+++ b/src/basename.js
@@ -1,0 +1,2 @@
+const basename = process.env.NODE_ENV === "production" ? "/open-source/webpack-dashboard" : "";
+export default basename;

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,0 +1,29 @@
+/* global window */
+import React from "react";
+import Radium, { StyleRoot } from "radium";
+
+// Variables and Stylesheet
+import { Header, Footer } from "formidable-landers";
+
+class App extends React.Component {
+  render() {
+    const isBrowser = typeof window !== "undefined" && window.__STATIC_GENERATOR !== true;
+    return (
+      <StyleRoot radiumConfig={isBrowser ? { userAgent: window.navigator.userAgent } : null}>
+        <Header/>
+        {this.props.children}
+        <Footer/>
+      </StyleRoot>
+    );
+  }
+}
+
+App.propTypes = {
+  children: React.PropTypes.node
+};
+
+App.defaultProps = {
+  children: null
+};
+
+export default Radium(App);

--- a/src/components/entry.js
+++ b/src/components/entry.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { render } from "react-dom";
+import { renderToString } from "react-dom/server";
+import { Router, RouterContext, match, applyRouterMiddleware, useRouterHistory } from "react-router";
+import { createMemoryHistory, createHistory } from "history";
+import useScroll from "react-router-scroll";
+import { renderAsHTML } from "./title-meta";
+import ReactGA from "react-ga";
+
+import Index from "../../templates/index.hbs";
+import routes from "../routes";
+import basename from "../basename";
+
+// ----------------------------------------------------------------------------
+// With `static-site-generator-webpack-plugin`, the same bundle is responsible for
+// both 1.) telling the plugin what to render to HTML and
+// 2.) running the app on the client side. In other words, this entry point
+// the roles of `server/index` and `client/app`.
+// ----------------------------------------------------------------------------
+
+// Client render (optional):
+// `static-site-generator-webpack-plugin` supports shimming browser globals
+// so instead of checking whether the document is undefined (always false),
+// Check whether it’s being shimmed
+if (typeof window !== "undefined" && window.__STATIC_GENERATOR !== true) { //eslint-disable-line no-undef
+  const history = useRouterHistory(createHistory)({ basename });
+  // Add Google Analytics tracking for each page
+  ReactGA.initialize("UA-43290258-1");
+  history.listen((location) => {
+    const fullLocation = basename + location.pathname;
+    ReactGA.set({ page: fullLocation });
+    ReactGA.pageview(fullLocation);
+  });
+  render(
+    <Router
+      history={history}
+      routes={routes}
+      render={applyRouterMiddleware(useScroll())}
+    />,
+    document.getElementById("content")
+  );
+}
+
+// Exported static site renderer:
+export default (locals, callback) => {
+  // userAgent for radium vendor prefixing
+  global.navigator = {
+    userAgent: "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2454.85 Safari/537.36"
+  };
+
+  const history = useRouterHistory(createMemoryHistory)({ basename });
+  const location = history.createLocation(locals.path);
+  match({ routes, location, history }, (error, redirectLocation, renderProps) => {
+    const content = renderToString(<RouterContext {...renderProps} />);
+    callback(null, Index({
+      titleMeta: renderAsHTML(),
+      content,
+      bundleJs: locals.assets.main,
+      baseHref: `${basename}/`
+    }));
+  });
+};

--- a/src/components/title-meta.js
+++ b/src/components/title-meta.js
@@ -1,0 +1,32 @@
+import React from "react";
+import DocumentMeta from "react-document-meta";
+
+class TitleMeta extends React.Component {
+  render() {
+    const titleMeta = {
+      title: this.props.title,
+      meta: {
+        property: {
+          "og:title": this.props.title
+        }
+      }
+    };
+
+    return (
+      <DocumentMeta {...titleMeta}>
+        {this.props.children}
+      </DocumentMeta>
+    );
+  }
+}
+
+TitleMeta.propTypes = {
+  title: React.PropTypes.string,
+  children: React.PropTypes.node
+};
+
+export default TitleMeta;
+
+export const renderAsHTML = function () {
+  return DocumentMeta.renderAsHTML();
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { Route, IndexRoute } from "react-router";
+import Home from "./screens/home/index";
+
+// Components
+import App from "./components/app";
+
+module.exports = (
+  <Route path="/" component={App}>
+    <IndexRoute component={Home}/>
+  </Route>
+);

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+class Home extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>Webpack Dashboard</h1>
+        <p>A CLI dashboard for webpack dev server.</p>
+        <pre><code>npm install webpack-dashboard --save-dev</code></pre>
+      </div>
+    );
+  }
+}
+
+export default Home;

--- a/static-routes.js
+++ b/static-routes.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = [
+  "/"
+];

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  {{{titleMeta}}}
+  <meta name="description" content="A CLI dashboard for webpack dev server.">
+  <meta property="og:site_name" content="Webpack Dashboard" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="http://www.formidable.com/open-source/webpack-dashboard/" />
+  <meta property="og:description" content="A CLI dashboard for webpack dev server." />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <link rel="icon" href="./static/favicon.ico" type="image/x-icon">
+  <base href="{{baseHref}}" />
+  {{!-- Code Mirror --}}
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.0.0/codemirror.min.css"/>
+</head>
+<body>
+  <div id="content">{{{content}}}</div>
+  <script async defer type="text/javascript" src="{{bundleJs}}"></script>
+</body>
+</html>


### PR DESCRIPTION
This adds all of the basic files that we can build off of to create a static docs site for the webpack-dashboard project.

/cc @paulathevalley 
