### PR TITLE
Add Docs Site Skeleton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: node_js
+
+node_js:
+  - "4.2"
+  - "5.0"
+
+# Use container-based Travis infrastructure.
+sudo: false
+
+addons:
+  ssh_known_hosts:
+  - 192.241.218.94
+
+branches:
+  only:
+    - master
+
+before_install:
+  # GUI for real browsers.
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+  # Decrypt the key file
+  - openssl aes-256-cbc -K $encrypted_718217747736_key -iv $encrypted_718217747736_iv -in deploy_static.pem.enc -out ./deploy_static.pem -d
+
+  # Install npmv3 because of postinstall bugs in npmv2:
+  # See https://github.com/FormidableLabs/victory/issues/98
+  - npm install -g npm@3
+
+install:
+  - npm install
+
+script:
+  - npm test
+  - NODE_ENV=production node_modules/.bin/builder run build-static
+
+# Once build on Travis is working, automatically deploy it on master only:
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: ./deploy.sh
+  on:
+    branch: master

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Capture which build we are. Travis provides in the form of:
+# `GLOBAL_NUMBER.SUBBUILD_NUMBER`. We're going to want the subbuild number
+# so that we can detect the "first" vs. "other" builds.
+#
+# Bash hackery reference for `##*.` thing:
+# http://tecadmin.net/how-to-extract-filename-extension-in-shell-script/#
+BUILD_SUFFIX=${TRAVIS_JOB_NUMBER##*.}
+echo "BUILD_SUFFIX: ${BUILD_SUFFIX}"
+
+# Early exit if we aren't the first build.
+if [[ "${BUILD_SUFFIX}" != "1" ]]; then
+  echo "Build number: ${TRAVIS_JOB_NUMBER}. Skipping deployment."
+  exit 0
+fi
+
+# Otherwise, continue and do the actual deploy.
+echo "Build number: ${TRAVIS_JOB_NUMBER}. Starting deployment."
+
+# make sure key is permissive, but not too permissive
+chmod 600 deploy_static.pem
+# clean out any existing staging folder but make sure it exists
+ssh -i deploy_static.pem formidable@192.241.218.94 "rm -rf static/webpack-dashboard-docs-staging && mkdir static/webpack-dashboard-docs-staging"
+# copy the build to the staging arena; if this fails, site is still OK
+scp -i ./deploy_static.pem -rp ./build/* formidable@192.241.218.94:/home/formidable/static/webpack-dashboard-docs-staging
+# rename the staging arena to the actual component playground site
+ssh -i ./deploy_static.pem formidable@192.241.218.94 "rm -rf static/webpack-dashboard && mv static/webpack-dashboard-docs-staging/ static/webpack-dashboard"

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Route, IndexRoute } from "react-router";
 import Home from "./screens/home/index";
+import { Guide, Docs } from "./screens/docs/index";
 
 // Components
 import App from "./components/app";
@@ -8,5 +9,7 @@ import App from "./components/app";
 module.exports = (
   <Route path="/" component={App}>
     <IndexRoute component={Home}/>
+    <Route path="/docs" component={Docs}/>
+    <Route path="/docs/getting-started" component={Guide}/>
   </Route>
 );

--- a/src/screens/about/index.js
+++ b/src/screens/about/index.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+class About extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>About Webpack-Dashboard</h1>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=webpack-dashboard&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=webpack-dashboard&type=watch&count=true&size=large&v=2" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=webpack-dashboard&type=fork&count=true&size=large" frameBorder="0" scrolling="0" width="158px" height="30px"></iframe>
+        <p>Webpack-dashboard is a CLI dashboard plugin for webpack-dev-server. Feel like an astronaut when you run your build.</p>
+        <a href="https://github.com/FormidableLabs/webpack-dashboard/graphs/contributors">See Contributors</a>
+        {/*add top 5 contributors if we can figure out a good way with the github API*/}
+        <p>Formidable is a Seattle-based consultancy and development shop, focused on open-source, full-stack JavaScript
+         using React.js and Node.js, and the architecture of large-scale JavaScript applications. We build products for some
+          of the world&#8217;s biggest companies, while helping their internal teams develop smart, thoughtful, and scalable systems.</p>
+      </div>
+    );
+  }
+}
+
+export default About;

--- a/src/screens/docs/index.js
+++ b/src/screens/docs/index.js
@@ -1,0 +1,31 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import Ecology from "ecology";
+import GettingStarted from "../../../node_modules/webpack-dashboard/docs/getting-started.md";
+import Api from "../../../node_modules/webpack-dashboard/docs/api.md";
+
+class Guide extends React.Component {
+  render() {
+    return (
+      <Ecology
+        overview={GettingStarted}
+        scope={{React, ReactDOM}}
+        playgroundtheme="elegant"
+      />
+    );
+  }
+}
+
+class Docs extends React.Component {
+  render() {
+    return (
+      <Ecology
+        overview={Api}
+        scope={{React, ReactDOM}}
+        playgroundtheme="elegant"
+      />
+    );
+  }
+}
+
+export { Guide, Docs };

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -10,6 +10,7 @@ class Home extends React.Component {
         <h1>Webpack Dashboard</h1>
         <p>A CLI dashboard for webpack dev server.</p>
         <pre><code>npm install webpack-dashboard --save-dev</code></pre>
+        <iframe src="https://ghbtns.com/github-btn.html?user=formidablelabs&repo=webpack-dashboard&type=star&count=true&size=large" frameBorder="0" scrolling="0" width="160px" height="30px"></iframe>
         <a href="https://github.com/FormidableLabs/webpack-dashboard">Source Code on GitHub</a>
         <br/>
         <a href="https://github.com/FormidableLabs/webpack-dashboard/issues">Report an Issue</a>

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -7,6 +7,14 @@ class Home extends React.Component {
         <h1>Webpack Dashboard</h1>
         <p>A CLI dashboard for webpack dev server.</p>
         <pre><code>npm install webpack-dashboard --save-dev</code></pre>
+        <a href="https://github.com/FormidableLabs/webpack-dashboard">Source Code on GitHub</a>
+        <br/>
+        <a href="https://github.com/FormidableLabs/webpack-dashboard/issues">Report an Issue</a>
+        <p>When using webpack, especially for a dev server, you are probably used to seeing something like this:</p>
+        <img src="http://i.imgur.com/p1uAqkD.png" alt="webpack output in terminal"/>
+        <p>That's cool, but it&#8217;s mostly noisy and scrolly and not super helpful. This plugin changes that. Now when 
+        you run your dev server, you basically work at NASA:</p>
+        <img src="http://i.imgur.com/5BWa1hB.png" alt="webpack output in terminal with webpack-dashboard" />
       </div>
     );
   }

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -15,6 +15,7 @@ class Home extends React.Component {
         <p>That's cool, but it&#8217;s mostly noisy and scrolly and not super helpful. This plugin changes that. Now when 
         you run your dev server, you basically work at NASA:</p>
         <img src="http://i.imgur.com/5BWa1hB.png" alt="webpack output in terminal with webpack-dashboard" />
+      {/*Getting started will live here*/}
       </div>
     );
   }

--- a/src/screens/home/index.js
+++ b/src/screens/home/index.js
@@ -1,4 +1,7 @@
 import React from "react";
+import Radium from "radium";
+import { Link } from "react-router";
+const RadiumLink = Radium(Link);
 
 class Home extends React.Component {
   render() {
@@ -15,7 +18,7 @@ class Home extends React.Component {
         <p>That's cool, but it&#8217;s mostly noisy and scrolly and not super helpful. This plugin changes that. Now when 
         you run your dev server, you basically work at NASA:</p>
         <img src="http://i.imgur.com/5BWa1hB.png" alt="webpack output in terminal with webpack-dashboard" />
-      {/*Getting started will live here*/}
+        <RadiumLink to="/docs/getting-started">Let&#8217;s Get Started</RadiumLink>
       </div>
     );
   }

--- a/static-routes.js
+++ b/static-routes.js
@@ -1,5 +1,7 @@
 "use strict";
 
 module.exports = [
-  "/"
+  "/",
+  "/docs",
+  "/docs/getting-started"
 ];


### PR DESCRIPTION
Adds the skeleton of the docs site for webpack dashboard. Copy is in draft form, no styling applied.

cc/ @paulathevalley @kenwheeler 
